### PR TITLE
fix escaping column names

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ exports.handler = function (event, context, callback) {
     let query = escape('SELECT * FROM %I WHERE "id" in %L;', options.table, options.uuids)
     const res = await(masterClient.query(query))
 
-    const fields = map(res.fields, 'name')
+    const fields = map(res.fields, (field) => { return escape.ident(field.name) })
     const values = map(res.rows, (row) => { return escape('(%s)', encodedValues(row)) })
     query = escape('INSERT INTO %I (%s) VALUES ', options.table, fields)
     query = query + values.join(', ')


### PR DESCRIPTION
`select id, primary from person_websites limit 10` won't work because primary is a reserved string.
Running the through `ident` will quote it if it is an identifier.
![image](https://user-images.githubusercontent.com/1080613/38695786-4a543382-3e5b-11e8-8815-cf4af9ae6314.png)
