### PR TITLE
have serverless try to make a key

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -17,6 +17,10 @@ provider:
     managed_by: serverless-framework
     function: lambda
   environment: ${file(serverless/environment.js)}
+  apiGateway:
+    apiKeys:
+      - name: mpdx-${env:PROJECT_NAME}-${self:custom.environmentMap.${env:ENVIRONMENT}}
+        value: ${env:AWS_API_GATEWAY_KEY}
 
 package:
   individually: true

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,10 +17,9 @@ provider:
     managed_by: serverless-framework
     function: lambda
   environment: ${file(serverless/environment.js)}
-  apiGateway:
-    apiKeys:
-      - name: mpdx-${env:PROJECT_NAME}-${self:custom.environmentMap.${env:ENVIRONMENT}}
-        value: ${env:AWS_API_GATEWAY_KEY}
+  apiKeys:
+    - name: mpdx-${env:PROJECT_NAME}-${self:custom.environmentMap.${env:ENVIRONMENT}}
+      value: ${env:AWS_API_GATEWAY_KEY}
 
 package:
   individually: true


### PR DESCRIPTION
https://www.serverless.com/framework/docs/providers/aws/events/apigateway/#setting-api-keys-for-your-rest-api

Config changed based on test from from v1 tag: https://github.com/serverless/serverless/blob/v1.83.3/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
We will probably have to change if/when we upgrade to serverless v2